### PR TITLE
Pasta Thrall Blacklist

### DIFF
--- a/scripts/gain.ash
+++ b/scripts/gain.ash
@@ -111,7 +111,7 @@ void initialiseModifiers()
 initialiseModifiers();
 
 //FIXME support asdon
-string __gain_version = "1.0.5";
+string __gain_version = "1.0.6";
 boolean __gain_setting_confirm = false;
 
 boolean [item] __modify_blocked_items = $items[M-242,snake,sparkler,Mer-kin strongjuice,Mer-kin smartjuice,Mer-kin cooljuice];
@@ -121,10 +121,16 @@ int __maximum_meat_to_spend = 100000;
 
 int __starting_meat = -1;
 int __meat_spent = 0;
-if (my_class() == $class[turtle tamer])
+switch (my_class())
 {
-	foreach s in $skills[Blessing of the Storm Tortoise,Blessing of She-Who-Was,Blessing of the War Snapper]
-		__modify_blocked_skills[s] = true;
+	case $class[turtle tamer]:
+		foreach s in $skills[Blessing of the Storm Tortoise,Blessing of She-Who-Was,Blessing of the War Snapper]
+			__modify_blocked_skills[s] = true;
+		break;
+	case $class[pastamancer]:
+		foreach s in $skills[Bind Vampieroghi,Bind Vermincelli,Bind Angel Hair Wisp,Bind Undead Elbow Macaroni,Bind Penne Dreadful,Bind Spaghetti Elemental,Bind Lasagmbie,Bind Spice Ghost]
+			__modify_blocked_skills[s] = true;
+		break;
 }
 
 static


### PR DESCRIPTION
This patch prevents the script from attempting to use Pasta Thrall binding skills when the player is a Pastamancer, since doing so won’t give the expected effect. 